### PR TITLE
feat: Add GPUI Components Skill

### DIFF
--- a/skills/gpui-components/SKILL.md
+++ b/skills/gpui-components/SKILL.md
@@ -1,0 +1,295 @@
+---
+name: gpui-components
+description: Generates Rust code for GPUI desktop UI components following Zed editor patterns. Use when building desktop applications with gpui crate, creating themed UI components, implementing autocomplete/completions, building command palettes, or working with the gpui-component library. Covers RenderOnce components, Entity state management, theming with ActiveTheme, and Zed-style UI patterns.
+version: 1.0.0
+---
+
+# GPUI Components Skill
+
+Generates production-ready Rust code for GPUI desktop UI components following patterns from Zed editor and gpui-component library.
+
+## When to Use This Skill
+
+- Building desktop UI applications with GPUI framework
+- Creating custom components using `RenderOnce` or `Render` traits
+- Implementing themed components with `ActiveTheme`
+- Building autocomplete/completion menus
+- Creating command palettes and popup menus
+- Working with `gpui-component` crate
+
+## Core GPUI Concepts
+
+### Application Setup
+
+```rust
+use gpui::{Application, Window, Context, div, px, rgb};
+use gpui_component::{init, Root, Theme};
+
+fn main() {
+    Application::new().run(|cx| {
+        // Initialize gpui-component
+        gpui_component::init(cx);
+        
+        cx.open_window(
+            WindowOptions::default(),
+            |window, cx| Root::new(MyApp::new(cx), window, cx)
+        );
+    });
+}
+```
+
+### Component Patterns
+
+#### RenderOnce (Stateless)
+```rust
+use gpui::{IntoElement, RenderOnce, Styled, div};
+
+#[derive(IntoElement)]
+pub struct MyButton {
+    label: SharedString,
+    variant: ButtonVariant,
+}
+
+impl RenderOnce for MyButton {
+    fn render(self, window: &mut Window, cx: &mut App) -> impl IntoElement {
+        div()
+            .px_3()
+            .py_2()
+            .bg(cx.theme().primary)
+            .text_color(cx.theme().primary_foreground)
+            .rounded_md()
+            .child(self.label)
+    }
+}
+```
+
+#### Render with Entity (Stateful)
+```rust
+use gpui::{Entity, Render, Context};
+
+pub struct Counter {
+    count: i32,
+}
+
+impl Render for Counter {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        div()
+            .flex()
+            .gap_2()
+            .child(Button::new("dec").on_click(cx.listener(|this, _, _, cx| {
+                this.count -= 1;
+                cx.notify();
+            })))
+            .child(format!("Count: {}", self.count))
+            .child(Button::new("inc").on_click(cx.listener(|this, _, _, cx| {
+                this.count += 1;
+                cx.notify();
+            })))
+    }
+}
+```
+
+## Available Components (gpui-component)
+
+### Form Components
+- `Button` - Buttons with variants (primary, danger, ghost, link)
+- `Input` - Text input with LSP completion support
+- `NumberInput` - Numeric input with step controls
+- `Checkbox` - Checkbox with label
+- `Switch` - Toggle switch
+- `Radio` - Radio button groups
+- `Select` - Dropdown select
+- `Slider` - Range slider
+
+### Layout Components
+- `Dialog` - Modal dialogs
+- `Popover` - Popup popovers
+- `Menu` / `PopupMenu` - Menus and context menus
+- `Tab` - Tab navigation
+- `Accordion` - Collapsible sections
+- `Sidebar` - Sidebar navigation
+- `Dock` - Dockable panels
+
+### Display Components
+- `Badge` - Status badges
+- `Avatar` - User avatars
+- `Icon` - Icon display (IconName enum)
+- `Label` - Text labels
+- `Tooltip` - Tooltips
+- `Notification` - Toast notifications
+
+### Data Components
+- `Table` - Data tables
+- `List` / `VirtualList` - Scrollable lists
+- `Tree` - Tree view
+- `Chart` - Charts and plots
+
+## Theming
+
+### Accessing Theme
+```rust
+use gpui_component::ActiveTheme;
+
+fn render(&mut self, window: &mut Window, cx: &mut App) -> impl IntoElement {
+    div()
+        .bg(cx.theme().background)
+        .text_color(cx.theme().foreground)
+        .border_1()
+        .border_color(cx.theme().border)
+}
+```
+
+### Theme Colors
+```rust
+// Background colors
+cx.theme().background      // Primary background
+cx.theme().secondary       // Secondary background  
+cx.theme().muted          // Muted background
+cx.theme().card           // Card background
+
+// Foreground colors
+cx.theme().foreground     // Primary text
+cx.theme().muted_foreground // Muted text
+
+// Semantic colors
+cx.theme().primary        // Primary accent
+cx.theme().destructive    // Danger/error
+cx.theme().success        // Success
+cx.theme().warning        // Warning
+
+// Border colors
+cx.theme().border         // Default border
+cx.theme().ring           // Focus ring
+```
+
+## Component Examples
+
+### Button Usage
+```rust
+use gpui_component::button::{Button, ButtonVariants};
+
+Button::new("save")
+    .label("Save")
+    .icon(IconName::Save)
+    .primary()
+    .on_click(cx.listener(|this, _, window, cx| {
+        this.save(window, cx);
+    }))
+```
+
+### Input with State
+```rust
+use gpui_component::input::{Input, InputState};
+
+// Create state
+let input_state = cx.new(|cx| InputState::new(cx));
+
+// In render:
+Input::new(&self.input_state)
+    .placeholder("Enter text...")
+    .cleanable(true)
+```
+
+### PopupMenu / Command Palette
+```rust
+use gpui_component::menu::{PopupMenu, PopupMenuItem};
+
+let menu = cx.new(|cx| {
+    PopupMenu::build(cx, |menu, window, cx| {
+        menu.menu_item(PopupMenuItem::new("New File")
+            .icon(IconName::FilePlus)
+            .action(Box::new(NewFile)))
+        .separator()
+        .menu_item(PopupMenuItem::new("Save")
+            .icon(IconName::Save)
+            .action(Box::new(Save)))
+    })
+});
+```
+
+### Completion Provider
+```rust
+use gpui_component::input::{CompletionProvider, InputState};
+
+struct MyCompletionProvider;
+
+impl CompletionProvider for MyCompletionProvider {
+    fn completions(
+        &self,
+        text: &Rope,
+        offset: usize,
+        trigger: CompletionContext,
+        window: &mut Window,
+        cx: &mut Context<InputState>,
+    ) -> Task<Result<CompletionResponse>> {
+        let items = vec![
+            CompletionItem {
+                label: "option1".into(),
+                ..Default::default()
+            },
+        ];
+        Task::ready(Ok(CompletionResponse::Array(items)))
+    }
+    
+    fn is_completion_trigger(
+        &self,
+        offset: usize,
+        new_text: &str,
+        cx: &mut Context<InputState>,
+    ) -> bool {
+        new_text == "/" || new_text == "@"
+    }
+}
+```
+
+## Reference Files
+
+For detailed patterns, read:
+- `reference/components.md` - Full component API
+- `reference/theming.md` - Theme system details
+- `reference/input-lsp.md` - Input with completions
+- `reference/menus.md` - Menu and command palette
+
+## Project Setup
+
+### Cargo.toml
+```toml
+[dependencies]
+gpui = "0.2"
+gpui-component = { version = "0.4", features = ["webview"] }
+```
+
+### Basic App Structure
+```rust
+use gpui::*;
+use gpui_component::*;
+
+struct App {
+    // state
+}
+
+impl Render for App {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        Root::new(
+            div()
+                .size_full()
+                .flex()
+                .flex_col()
+                .bg(cx.theme().background)
+                .child(self.render_toolbar(window, cx))
+                .child(self.render_content(window, cx)),
+            window,
+            cx
+        )
+    }
+}
+
+fn main() {
+    Application::new().run(|cx| {
+        gpui_component::init(cx);
+        cx.open_window(WindowOptions::default(), |window, cx| {
+            cx.new(|cx| App::new(cx))
+        });
+    });
+}
+```

--- a/skills/gpui-components/examples/basic_app.rs
+++ b/skills/gpui-components/examples/basic_app.rs
@@ -1,0 +1,75 @@
+//! Basic GPUI application with gpui-component
+//! cargo run --example basic_app
+
+use gpui::*;
+use gpui_component::*;
+use gpui_component::button::{Button, ButtonVariants};
+use gpui_component::input::{Input, InputState};
+
+struct App {
+    input_state: Entity<InputState>,
+    count: i32,
+}
+
+impl App {
+    fn new(cx: &mut Context<Self>) -> Self {
+        Self {
+            input_state: cx.new(|cx| InputState::new(cx)),
+            count: 0,
+        }
+    }
+}
+
+impl Render for App {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        Root::new(
+            div()
+                .size_full()
+                .flex()
+                .flex_col()
+                .gap_4()
+                .p_6()
+                .bg(cx.theme().background)
+                .child(
+                    div().text_xl().font_weight(FontWeight::BOLD)
+                        .child("GPUI Demo")
+                )
+                .child(
+                    Input::new(&self.input_state)
+                        .placeholder("Type something...")
+                        .cleanable(true)
+                )
+                .child(
+                    h_flex().gap_2().items_center()
+                        .child(Button::new("dec").icon(IconName::Minus)
+                            .on_click(cx.listener(|this, _, _, cx| {
+                                this.count -= 1;
+                                cx.notify();
+                            })))
+                        .child(div().px_4().py_2().bg(cx.theme().secondary)
+                            .child(format!("{}", self.count)))
+                        .child(Button::new("inc").icon(IconName::Plus)
+                            .on_click(cx.listener(|this, _, _, cx| {
+                                this.count += 1;
+                                cx.notify();
+                            })))
+                )
+                .child(
+                    h_flex().gap_2()
+                        .child(Button::new("b1").label("Primary").primary())
+                        .child(Button::new("b2").label("Danger").danger())
+                        .child(Button::new("b3").label("Ghost").ghost())
+                ),
+            window, cx,
+        )
+    }
+}
+
+fn main() {
+    Application::new().run(|cx| {
+        gpui_component::init(cx);
+        cx.open_window(WindowOptions::default(), |window, cx| {
+            cx.new(|cx| App::new(cx))
+        }).unwrap();
+    });
+}

--- a/skills/gpui-components/examples/markdown_editor.rs
+++ b/skills/gpui-components/examples/markdown_editor.rs
@@ -1,0 +1,109 @@
+//! Markdown editor with slash commands
+//! cargo run --example markdown_editor
+
+use std::sync::Arc;
+use anyhow::Result;
+use gpui::*;
+use gpui_component::*;
+use gpui_component::input::{Input, InputState, CompletionProvider};
+use lsp_types::{CompletionContext, CompletionItem, CompletionItemKind, CompletionResponse};
+use ropey::Rope;
+
+struct SlashCommandProvider;
+
+impl CompletionProvider for SlashCommandProvider {
+    fn completions(
+        &self,
+        text: &Rope,
+        offset: usize,
+        _trigger: CompletionContext,
+        _window: &mut Window,
+        _cx: &mut Context<InputState>,
+    ) -> Task<Result<CompletionResponse>> {
+        let text_str = text.slice(..offset).to_string();
+        
+        if let Some(slash_pos) = text_str.rfind('/') {
+            let query = &text_str[slash_pos + 1..];
+            let commands = [
+                ("heading", "# ", "Insert heading"),
+                ("code", "```\n\n```", "Insert code block"),
+                ("list", "- ", "Insert bullet list"),
+                ("quote", "> ", "Insert blockquote"),
+                ("table", "| Col1 | Col2 |\n|------|------|", "Insert table"),
+            ];
+            
+            let items: Vec<CompletionItem> = commands
+                .iter()
+                .filter(|(name, _, _)| name.starts_with(query))
+                .map(|(name, insert, detail)| CompletionItem {
+                    label: format!("/{}", name),
+                    kind: Some(CompletionItemKind::SNIPPET),
+                    detail: Some(detail.to_string()),
+                    insert_text: Some(insert.to_string()),
+                    ..Default::default()
+                })
+                .collect();
+            
+            return Task::ready(Ok(CompletionResponse::Array(items)));
+        }
+        Task::ready(Ok(CompletionResponse::Array(vec![])))
+    }
+    
+    fn is_completion_trigger(&self, _: usize, new_text: &str, _: &mut Context<InputState>) -> bool {
+        new_text == "/"
+    }
+}
+
+struct MarkdownEditor {
+    input_state: Entity<InputState>,
+}
+
+impl MarkdownEditor {
+    fn new(cx: &mut Context<Self>) -> Self {
+        let input_state = cx.new(|cx| {
+            let mut state = InputState::new(cx)
+                .multi_line(true)
+                .text("# Welcome\n\nType `/` for commands.\n");
+            state.set_completion_provider(Arc::new(SlashCommandProvider), cx);
+            state
+        });
+        Self { input_state }
+    }
+}
+
+impl Render for MarkdownEditor {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        Root::new(
+            div()
+                .size_full()
+                .flex()
+                .flex_col()
+                .bg(cx.theme().background)
+                .child(
+                    h_flex().px_4().py_2().bg(cx.theme().secondary)
+                        .child(Icon::new(IconName::FileText).color(cx.theme().primary))
+                        .child(div().font_weight(FontWeight::SEMIBOLD).child("Markdown Editor"))
+                )
+                .child(
+                    div().flex_1().p_4()
+                        .child(Input::new(&self.input_state).h_full())
+                ),
+            window, cx,
+        )
+    }
+}
+
+fn main() {
+    Application::new().run(|cx| {
+        gpui_component::init(cx);
+        cx.open_window(
+            WindowOptions {
+                window_bounds: Some(WindowBounds::Windowed(Bounds::centered(
+                    None, size(px(800.0), px(600.0)), cx,
+                ))),
+                ..Default::default()
+            },
+            |window, cx| cx.new(|cx| MarkdownEditor::new(cx)),
+        ).unwrap();
+    });
+}

--- a/skills/gpui-components/reference/components.md
+++ b/skills/gpui-components/reference/components.md
@@ -1,0 +1,232 @@
+# GPUI Component API Reference
+
+Complete API for gpui-component library components.
+
+## Button
+
+```rust
+use gpui_component::button::{Button, ButtonVariants, ButtonRounded};
+
+// Basic button
+Button::new("id")
+    .label("Click me")
+    
+// With icon
+Button::new("save")
+    .icon(IconName::Save)
+    .label("Save")
+    
+// Variants
+Button::new("id").primary()      // Primary style
+Button::new("id").danger()       // Destructive
+Button::new("id").success()      // Success
+Button::new("id").warning()      // Warning
+Button::new("id").ghost()        // Ghost/transparent
+Button::new("id").link()         // Link style
+Button::new("id").text()         // Text only, no padding
+
+// Sizes
+Button::new("id").xsmall()
+Button::new("id").small()
+Button::new("id").medium()       // default
+Button::new("id").large()
+
+// States
+Button::new("id").disabled(true)
+Button::new("id").loading(true)
+Button::new("id").selected(true)
+
+// Click handler
+Button::new("id")
+    .on_click(cx.listener(|this, event, window, cx| {
+        // handle click
+    }))
+
+// With tooltip
+Button::new("id")
+    .tooltip("Save file", Some(Box::new(Save)))
+```
+
+## Input
+
+```rust
+use gpui_component::input::{Input, InputState};
+
+// Create state entity
+let state = cx.new(|cx| InputState::new(cx));
+
+// Basic input
+Input::new(&state)
+    .placeholder("Enter text...")
+
+// Password input
+let state = cx.new(|cx| InputState::new(cx).masked(true));
+Input::new(&state).mask_toggle()
+
+// Multi-line
+let state = cx.new(|cx| InputState::new(cx).multi_line(true));
+Input::new(&state).h(px(200.0))
+
+// With prefix/suffix
+Input::new(&state)
+    .prefix(Icon::new(IconName::Search))
+    .suffix(Icon::new(IconName::X))
+
+// Cleanable (show clear button)
+Input::new(&state).cleanable(true)
+```
+
+### InputState API
+
+```rust
+// Create
+InputState::new(cx)
+InputState::new(cx).text("initial value")
+InputState::new(cx).multi_line(true)
+InputState::new(cx).masked(true)  // password
+
+// Read/write text
+state.read(cx).text()            // Get text as &str
+state.update(cx, |s, cx| {
+    s.set_text("new text", window, cx);
+});
+```
+
+## Select
+
+```rust
+use gpui_component::select::Select;
+
+Select::new("size-select")
+    .items(vec![
+        ListItem::new("sm").label("Small"),
+        ListItem::new("md").label("Medium"),
+        ListItem::new("lg").label("Large"),
+    ])
+    .selected_value("md")
+    .placeholder("Select size...")
+    .on_select(cx.listener(|this, value, window, cx| {
+        this.size = value;
+        cx.notify();
+    }))
+```
+
+## Checkbox & Switch
+
+```rust
+use gpui_component::checkbox::Checkbox;
+use gpui_component::switch::Switch;
+
+Checkbox::new("agree")
+    .label("I agree to terms")
+    .checked(self.agreed)
+    .on_click(cx.listener(|this, checked, window, cx| {
+        this.agreed = *checked;
+        cx.notify();
+    }))
+
+Switch::new("dark-mode")
+    .checked(self.dark_mode)
+    .label("Dark Mode")
+    .on_click(cx.listener(|this, checked, window, cx| {
+        this.dark_mode = *checked;
+        cx.notify();
+    }))
+```
+
+## Dialog
+
+```rust
+use gpui_component::dialog::Dialog;
+
+Dialog::new("confirm-dialog")
+    .title("Confirm Action")
+    .content(|window, cx| {
+        div().child("Are you sure?")
+    })
+    .footer(|window, cx| {
+        h_flex()
+            .gap_2()
+            .child(Button::new("cancel").label("Cancel").ghost())
+            .child(Button::new("confirm").label("Confirm").primary())
+    })
+    .open(self.dialog_open)
+```
+
+## PopupMenu
+
+```rust
+use gpui_component::menu::{PopupMenu, PopupMenuItem};
+
+let menu = cx.new(|cx| {
+    PopupMenu::build(cx, |menu, window, cx| {
+        menu.menu_item(PopupMenuItem::new("New File")
+                .icon(IconName::FilePlus)
+                .action(Box::new(NewFile)))
+            .separator()
+            .menu_item(PopupMenuItem::new("Save")
+                .icon(IconName::Save)
+                .action(Box::new(Save)))
+    })
+});
+
+// Show menu
+menu.update(cx, |m, cx| m.show(window, cx));
+```
+
+## Tab
+
+```rust
+use gpui_component::tab::{Tab, TabBar};
+
+TabBar::new("main-tabs")
+    .child(Tab::new("tab1").label("Editor"))
+    .child(Tab::new("tab2").label("Terminal"))
+    .active_tab("tab1")
+    .on_select(cx.listener(|this, tab_id, window, cx| {
+        this.active_tab = tab_id.clone();
+        cx.notify();
+    }))
+```
+
+## VirtualList
+
+```rust
+use gpui_component::virtual_list::v_virtual_list;
+
+v_virtual_list(
+    "items-list",
+    self.items.len(),
+    move |idx, window, cx| {
+        let item = &self.items[idx];
+        div().p_2().child(item.label.clone())
+    }
+)
+.item_height(px(32.0))
+```
+
+## Icon
+
+```rust
+use gpui_component::icon::{Icon, IconName};
+
+Icon::new(IconName::Save)
+Icon::new(IconName::FilePlus)
+Icon::new(IconName::Settings)
+Icon::new(IconName::Search)
+Icon::new(IconName::Check)
+Icon::new(IconName::X)
+
+// Custom size/color
+Icon::new(IconName::Save).size(px(24.0))
+Icon::new(IconName::Check).color(cx.theme().success)
+```
+
+## Kbd (Keyboard Shortcut)
+
+```rust
+use gpui_component::kbd::Kbd;
+
+Kbd::new("Cmd+S")
+Kbd::new("Ctrl+Shift+P")
+```

--- a/skills/gpui-components/reference/input-lsp.md
+++ b/skills/gpui-components/reference/input-lsp.md
@@ -1,0 +1,86 @@
+# Input with LSP Completions
+
+The Input component supports LSP-style completions for autocomplete, slash commands, and intelligent suggestions.
+
+## CompletionProvider Trait
+
+```rust
+use gpui_component::input::{CompletionProvider, InputState};
+use lsp_types::{CompletionContext, CompletionItem, CompletionResponse};
+use ropey::Rope;
+
+struct SlashCommandProvider;
+
+impl CompletionProvider for SlashCommandProvider {
+    fn completions(
+        &self,
+        text: &Rope,
+        offset: usize,
+        _trigger: CompletionContext,
+        _window: &mut Window,
+        _cx: &mut Context<InputState>,
+    ) -> Task<Result<CompletionResponse>> {
+        let text_str = text.slice(..offset).to_string();
+        
+        if let Some(slash_pos) = text_str.rfind('/') {
+            let query = &text_str[slash_pos + 1..];
+            
+            let commands = [
+                ("heading", "# ", "Insert heading"),
+                ("code", "```\n\n```", "Insert code block"),
+                ("list", "- ", "Insert bullet list"),
+            ];
+            
+            let items: Vec<CompletionItem> = commands
+                .iter()
+                .filter(|(name, _, _)| name.starts_with(query))
+                .map(|(name, insert, detail)| CompletionItem {
+                    label: format!("/{}", name),
+                    detail: Some(detail.to_string()),
+                    insert_text: Some(insert.to_string()),
+                    ..Default::default()
+                })
+                .collect();
+            
+            return Task::ready(Ok(CompletionResponse::Array(items)));
+        }
+        
+        Task::ready(Ok(CompletionResponse::Array(vec![])))
+    }
+    
+    fn is_completion_trigger(
+        &self,
+        _offset: usize,
+        new_text: &str,
+        _cx: &mut Context<InputState>,
+    ) -> bool {
+        new_text == "/"
+    }
+}
+```
+
+## Attaching Provider to Input
+
+```rust
+use std::sync::Arc;
+
+let input_state = cx.new(|cx| {
+    let mut state = InputState::new(cx).multi_line(true);
+    state.set_completion_provider(Arc::new(SlashCommandProvider), cx);
+    state
+});
+```
+
+## Completion Item Properties
+
+```rust
+use lsp_types::{CompletionItem, CompletionItemKind};
+
+CompletionItem {
+    label: "myFunction".to_string(),
+    kind: Some(CompletionItemKind::FUNCTION),
+    detail: Some("fn myFunction() -> i32".to_string()),
+    insert_text: Some("myFunction()".to_string()),
+    ..Default::default()
+}
+```

--- a/skills/gpui-components/reference/menus.md
+++ b/skills/gpui-components/reference/menus.md
@@ -1,0 +1,102 @@
+# Menus and Command Palette
+
+## PopupMenu
+
+```rust
+use gpui_component::menu::{PopupMenu, PopupMenuItem};
+
+fn build_command_palette(cx: &mut App) -> Entity<PopupMenu> {
+    cx.new(|cx| {
+        PopupMenu::build(cx, |menu, window, cx| {
+            menu
+                .menu_item(PopupMenuItem::label("File"))
+                .menu_item(PopupMenuItem::new("New File")
+                    .icon(IconName::FilePlus)
+                    .action(Box::new(NewFile)))
+                .menu_item(PopupMenuItem::new("Save")
+                    .icon(IconName::Save)
+                    .action(Box::new(Save)))
+                .separator()
+                .menu_item(PopupMenuItem::new("Quit")
+                    .icon(IconName::X)
+                    .on_click(|_, window, cx| cx.quit()))
+        })
+    })
+}
+```
+
+## Menu Item Types
+
+```rust
+// Standard item
+PopupMenuItem::new("Label")
+    .icon(IconName::Save)
+    .action(Box::new(MyAction))
+
+// Separator
+PopupMenuItem::separator()
+
+// Label (non-interactive header)
+PopupMenuItem::label("Section Header")
+
+// Submenu
+PopupMenuItem::submenu("More Options", submenu_entity)
+
+// Custom element
+PopupMenuItem::element(|window, cx| {
+    h_flex().gap_2().child(Icon::new(IconName::User)).child("Custom")
+})
+```
+
+## Actions and Keyboard Shortcuts
+
+```rust
+use gpui::{actions, Action, KeyBinding};
+
+actions!(my_app, [NewFile, Save, Undo, Redo, ToggleSidebar]);
+
+fn init(cx: &mut App) {
+    cx.bind_keys([
+        KeyBinding::new("cmd-n", NewFile, None),
+        KeyBinding::new("cmd-s", Save, None),
+        KeyBinding::new("cmd-z", Undo, None),
+        KeyBinding::new("cmd-shift-p", ToggleCommandPalette, None),
+    ]);
+}
+```
+
+## Showing Menu
+
+```rust
+// At mouse position
+menu.update(cx, |m, cx| m.show(window, cx));
+
+// At specific position
+menu.update(cx, |m, cx| {
+    m.show_at(Point::new(px(100.0), px(200.0)), window, cx);
+});
+```
+
+## ContextMenu (Right-click)
+
+```rust
+use gpui_component::menu::ContextMenuExt;
+
+div()
+    .context_menu(|window, cx| {
+        PopupMenu::build(cx, |menu, window, cx| {
+            menu.menu_item(PopupMenuItem::new("Cut"))
+                .menu_item(PopupMenuItem::new("Copy"))
+                .menu_item(PopupMenuItem::new("Paste"))
+        })
+    })
+    .child("Right-click me")
+```
+
+## Keyboard Navigation
+
+PopupMenu handles these keys automatically:
+- `Up/Down` - Navigate items
+- `Enter` - Select item
+- `Escape` - Close menu
+- `Left/Right` - Navigate submenus

--- a/skills/gpui-components/reference/theming.md
+++ b/skills/gpui-components/reference/theming.md
@@ -1,0 +1,78 @@
+# GPUI Theming Reference
+
+## Theme Access
+
+Use the `ActiveTheme` trait to access theme colors:
+
+```rust
+use gpui_component::ActiveTheme;
+
+impl Render for MyComponent {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        div()
+            .bg(cx.theme().background)
+            .text_color(cx.theme().foreground)
+    }
+}
+```
+
+## Theme Colors
+
+### Backgrounds
+```rust
+cx.theme().background          // Main background
+cx.theme().secondary           // Secondary/sidebar background
+cx.theme().muted               // Muted/disabled background
+cx.theme().card                // Card/elevated background
+cx.theme().popover             // Popover/dropdown background
+```
+
+### Foregrounds
+```rust
+cx.theme().foreground          // Primary text
+cx.theme().secondary_foreground // Secondary text
+cx.theme().muted_foreground    // Muted/placeholder text
+cx.theme().accent_foreground   // Text on accent background
+```
+
+### Semantic Colors
+```rust
+cx.theme().primary             // Primary action color
+cx.theme().primary_foreground  // Text on primary
+cx.theme().destructive         // Destructive/danger color
+cx.theme().success             // Success color
+cx.theme().warning             // Warning color
+```
+
+### Border & Ring
+```rust
+cx.theme().border              // Default border color
+cx.theme().input               // Input border color
+cx.theme().ring                // Focus ring color
+```
+
+## Switching Themes
+
+```rust
+use gpui_component::theme::{Theme, ThemeMode};
+
+// Sync with system appearance
+Theme::sync_system_appearance(None, cx);
+
+// Set specific mode
+Theme::set_mode(ThemeMode::Dark, cx);
+Theme::set_mode(ThemeMode::Light, cx);
+```
+
+## Theme Properties
+
+```rust
+let theme = Theme::global(cx);
+
+theme.font_size          // Base font size (16px default)
+theme.font_family        // UI font family
+theme.mono_font_family   // Monospace font
+theme.radius             // General border radius
+theme.radius_lg          // Large border radius
+theme.shadow             // Whether to use shadows
+```


### PR DESCRIPTION
## Summary

Adds a new Claude skill for generating Rust GPUI desktop UI components following Zed editor patterns.

## Features

- **GPUI Component Generation**: Generates Rust code using gpui-component library patterns
- **Theming**: ActiveTheme trait with cx.theme() access for all colors
- **Input Components**: InputState with CompletionProvider for autocomplete and slash commands
- **Command Palette**: PopupMenu patterns for Cmd+Shift+P command interface
- **State Management**: Entity-based reactive state following GPUI patterns

## Components Covered

- Button (variants: primary, danger, success, ghost, link)
- Input (with LSP-style completions)
- Select, Checkbox, Switch, Radio
- Dialog, PopupMenu, Tab
- VirtualList, Table, Tree
- Icon, Badge, Tooltip, Kbd

## Reference Documentation

- `components.md` - Complete component API
- `theming.md` - Theme system and colors
- `input-lsp.md` - Autocomplete/slash commands
- `menus.md` - Command palette patterns

## Examples

- `basic_app.rs` - Simple GPUI desktop app
- `markdown_editor.rs` - Markdown editor with slash commands

## Testing

Verified by generating a 567-line command palette implementation with:
- Cmd+Shift+P keyboard shortcut
- Fuzzy command filtering
- Entity-based state management
- Full GPUI theming
- PopupMenu integration

## Related

- Based on https://www.gpui.rs/
- Uses patterns from https://github.com/AlexMikhalev/gpui-component
- Follows Zed editor architecture